### PR TITLE
Added Puppetfile to the list of recognized file extensions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
             ],
             "extensions": [
                 ".pp",
-                ".epp"
+                ".epp",
+                "Puppetfile"
             ],
             "configuration": "./puppet.configuration.json"
         }],


### PR DESCRIPTION
Tossed in Puppetfile into the extension's package.json so that there's parity to the rest of the incorporated puppet used files. Also I'm lazy and having to keep setting the language on it to Ruby was a bother.